### PR TITLE
Added 3 composable buttons

### DIFF
--- a/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
@@ -1,6 +1,7 @@
 package com.tpc.nudj.ui.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -24,9 +25,9 @@ fun PrimaryButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    isDark: Boolean
 ) {
-    val buttonColor = if (isDark) Purple else Orange
+
+    val buttonColor = if (isSystemInDarkTheme()) Purple else Orange
     val contentColor = Color.White
     val disabledBackgroundColor = buttonColor.copy(alpha = 0.6f)
     val disabledTextColor = contentColor.copy(alpha = 0.6f)
@@ -61,10 +62,9 @@ fun SecondaryButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    isDark: Boolean
 ) {
     val buttonColor = Color.White
-    val contentColor = if (isDark) Purple else Orange
+    val contentColor = if (isSystemInDarkTheme()) Purple else Orange
     val disabledBackgroundColor = buttonColor.copy(alpha = 0.6f)
     val disabledTextColor = contentColor.copy(alpha = 0.6f)
 
@@ -100,10 +100,8 @@ fun TertiaryButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    isDark: Boolean
 ) {
-    val buttonColor = if(isDark) Purple else Color.White
-    val contentColor = if (isDark) Color.White else Purple
+    val contentColor = if (isSystemInDarkTheme()) Color.White else Purple
 
     TextButton(
         onClick = onClick,
@@ -111,7 +109,6 @@ fun TertiaryButton(
         modifier = modifier
             .padding(16.dp),
         colors = ButtonDefaults.textButtonColors(
-            containerColor = buttonColor,
             contentColor = contentColor,
         )
     ) {
@@ -130,79 +127,44 @@ fun TertiaryButton(
 
 
 @Preview(showBackground = true, showSystemUi = false)
-@Composable
-fun PrimaryButtonLightModePreview(modifier: Modifier = Modifier) {
-    PrimaryButton(
-        text = "Edit",
-        onClick = {
-            // onClick logic
-        },
-        enabled = true,
-        isDark = false
-    )
-}
-
 @Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun PrimaryButtonDarkModePreview(modifier: Modifier = Modifier) {
+fun PrimaryButtonPreview(modifier: Modifier = Modifier) {
     PrimaryButton(
         text = "Edit",
         onClick = {
             // onClick logic
         },
-        enabled = true,
-        isDark = true
+        enabled = true
     )
 }
 
+
+@Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
 @Preview(showBackground = true, showSystemUi = false)
 @Composable
-fun SecondaryButtonLightModePreview(modifier: Modifier = Modifier) {
+fun SecondaryButtonPreview(modifier: Modifier = Modifier) {
     SecondaryButton(
         text = "Edit",
         onClick = {
             // onClick logic
         },
         enabled = true,
-        isDark = false
     )
 }
+
 
 @Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
-@Composable
-fun SecondaryButtonDarkModePreview(modifier: Modifier = Modifier) {
-    SecondaryButton(
-        text = "Edit",
-        onClick = {
-            // onClick logic
-        },
-        enabled = true,
-        isDark = true
-    )
-}
-
 @Preview(showBackground = true, showSystemUi = false)
 @Composable
-fun TertiaryButtonLightModePreview(modifier: Modifier = Modifier) {
+fun TertiaryButtonPreview(modifier: Modifier = Modifier) {
     TertiaryButton(
         text = "Edit",
         onClick = {
             // onClick logic
         },
         enabled = true,
-        isDark = false
     )
 }
 
-@Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
-@Composable
-fun TertiaryButtonDarkModePreview(modifier: Modifier = Modifier) {
-    TertiaryButton(
-        text = "Edit",
-        onClick = {
-            // onClick logic
-        },
-        enabled = true,
-        isDark = true
-    )
-}
+

--- a/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
@@ -1,2 +1,208 @@
 package com.tpc.nudj.ui.components
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.tpc.nudj.ui.theme.ClashDisplay
+import com.tpc.nudj.ui.theme.Orange
+import com.tpc.nudj.ui.theme.Purple
+
+@Composable
+fun PrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isDark: Boolean
+) {
+    val buttonColor = if (isDark) Purple else Orange
+    val contentColor = Color.White
+    val disabledBackgroundColor = buttonColor.copy(alpha = 0.6f)
+    val disabledTextColor = contentColor.copy(alpha = 0.6f)
+
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .padding(16.dp)
+        ,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = buttonColor ,
+            contentColor = contentColor,
+            disabledContainerColor = disabledBackgroundColor,
+            disabledContentColor = disabledTextColor
+        )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontFamily = ClashDisplay
+            ),
+            modifier = modifier
+                .padding(horizontal = 16.dp)
+        )
+    }
+}
+
+@Composable
+fun SecondaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isDark: Boolean
+) {
+    val buttonColor = Color.White
+    val contentColor = if (isDark) Purple else Orange
+    val disabledBackgroundColor = buttonColor.copy(alpha = 0.6f)
+    val disabledTextColor = contentColor.copy(alpha = 0.6f)
+
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .padding(16.dp)
+        ,
+        border = BorderStroke(1.dp, contentColor),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = buttonColor ,
+            contentColor = contentColor,
+            disabledContainerColor = disabledBackgroundColor,
+            disabledContentColor = disabledTextColor
+        )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontFamily = ClashDisplay
+            ),
+            modifier = modifier
+                .padding(horizontal = 16.dp)
+        )
+    }
+}
+
+
+@Composable
+fun TertiaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    isDark: Boolean
+) {
+    val buttonColor = if(isDark) Purple else Color.White
+    val contentColor = if (isDark) Color.White else Purple
+
+    TextButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .padding(16.dp),
+        colors = ButtonDefaults.textButtonColors(
+            containerColor = buttonColor,
+            contentColor = contentColor,
+        )
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                textDecoration = TextDecoration.Underline,
+                fontFamily = ClashDisplay
+            ),
+            modifier = modifier
+                .padding(horizontal = 16.dp)
+        )
+    }
+}
+
+
+
+@Preview(showBackground = true, showSystemUi = false)
+@Composable
+fun PrimaryButtonLightModePreview(modifier: Modifier = Modifier) {
+    PrimaryButton(
+        text = "Edit",
+        onClick = {
+            // onClick logic
+        },
+        enabled = true,
+        isDark = false
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PrimaryButtonDarkModePreview(modifier: Modifier = Modifier) {
+    PrimaryButton(
+        text = "Edit",
+        onClick = {
+            // onClick logic
+        },
+        enabled = true,
+        isDark = true
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = false)
+@Composable
+fun SecondaryButtonLightModePreview(modifier: Modifier = Modifier) {
+    SecondaryButton(
+        text = "Edit",
+        onClick = {
+            // onClick logic
+        },
+        enabled = true,
+        isDark = false
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun SecondaryButtonDarkModePreview(modifier: Modifier = Modifier) {
+    SecondaryButton(
+        text = "Edit",
+        onClick = {
+            // onClick logic
+        },
+        enabled = true,
+        isDark = true
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = false)
+@Composable
+fun TertiaryButtonLightModePreview(modifier: Modifier = Modifier) {
+    TertiaryButton(
+        text = "Edit",
+        onClick = {
+            // onClick logic
+        },
+        enabled = true,
+        isDark = false
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun TertiaryButtonDarkModePreview(modifier: Modifier = Modifier) {
+    TertiaryButton(
+        text = "Edit",
+        onClick = {
+            // onClick logic
+        },
+        enabled = true,
+        isDark = true
+    )
+}

--- a/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/Buttons.kt
@@ -25,9 +25,12 @@ fun PrimaryButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    isDarkModeEnabled: Boolean
 ) {
+    val isSystemDark = isSystemInDarkTheme()
+    val useDarkTheme = isDarkModeEnabled && isSystemDark
 
-    val buttonColor = if (isSystemInDarkTheme()) Purple else Orange
+    val buttonColor = if (useDarkTheme) Purple else Orange
     val contentColor = Color.White
     val disabledBackgroundColor = buttonColor.copy(alpha = 0.6f)
     val disabledTextColor = contentColor.copy(alpha = 0.6f)
@@ -56,15 +59,20 @@ fun PrimaryButton(
     }
 }
 
+
 @Composable
 fun SecondaryButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    isDarkModeEnabled: Boolean
 ) {
+    val isSystemDark = isSystemInDarkTheme()
+    val useDarkTheme = isDarkModeEnabled && isSystemDark
+
     val buttonColor = Color.White
-    val contentColor = if (isSystemInDarkTheme()) Purple else Orange
+    val contentColor = if (useDarkTheme) Purple else Orange
     val disabledBackgroundColor = buttonColor.copy(alpha = 0.6f)
     val disabledTextColor = contentColor.copy(alpha = 0.6f)
 
@@ -100,8 +108,12 @@ fun TertiaryButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    isDarkModeEnabled: Boolean
 ) {
-    val contentColor = if (isSystemInDarkTheme()) Color.White else Purple
+    val isSystemDark = isSystemInDarkTheme()
+    val useDarkTheme = isDarkModeEnabled && isSystemDark
+
+    val contentColor = if (useDarkTheme) Color.White else Purple
 
     TextButton(
         onClick = onClick,
@@ -125,7 +137,6 @@ fun TertiaryButton(
 }
 
 
-
 @Preview(showBackground = true, showSystemUi = false)
 @Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
 @Composable
@@ -135,7 +146,8 @@ fun PrimaryButtonPreview(modifier: Modifier = Modifier) {
         onClick = {
             // onClick logic
         },
-        enabled = true
+        enabled = true,
+        isDarkModeEnabled = true
     )
 }
 
@@ -150,6 +162,7 @@ fun SecondaryButtonPreview(modifier: Modifier = Modifier) {
             // onClick logic
         },
         enabled = true,
+        isDarkModeEnabled = true
     )
 }
 
@@ -164,6 +177,7 @@ fun TertiaryButtonPreview(modifier: Modifier = Modifier) {
             // onClick logic
         },
         enabled = true,
+        isDarkModeEnabled = true
     )
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.2"
+agp = "8.10.1"
 kotlin = "2.1.10"
 coreKtx = "1.16.0"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.9.2"
 kotlin = "2.1.10"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Fixes #2

> Added 3 button composables: Filled button named PrimaryButton, Outlined button named SecondaryButton and Text button named TertiaryButton.

Added both Light and Dark UI Previews of all three button composables separately.

## 🧩 Related Issue

Closes: #2

## 📸 Screenshots / UI Demo (If applicable)

> Add screenshots or screen recordings to showcase any visual/UI changes.

---

## ✅ Checklist

- ✅ My code follows the project's style and structure
- ✅ I’ve tested my changes locally
- ✅ I’ve not committed any files directly to `main`
- ✅ I’ve commented my approach in the linked issue
- ✅ My commit messages are clean and meaningful
- ✅ This PR focuses on one clear task/feature only

## 🧠 Brief Explanation of Approach

> I made 3 different functions for each of the button composable.
- Added necessary and important parameters in the function itself.
- Kept in mind the reusability of the code.

## 📢 Additional Notes (Optional)

> In the Figma design that was provided, the use of buttons in dark and light mode is not so clear. To tackle that issue, I had to pass on an extra parameter, isDark, in each of the functions, which is to take care of which button composable we might want. Like there was an orange colored filled button in the dark mode and light mode too.
![Screenshot (14)](https://github.com/user-attachments/assets/d7f5a470-2e5e-420d-aadd-6b27e03b2d97)
