### PR TITLE
feat: Added landing screen layout

### DIFF
--- a/app/src/main/java/com/tpc/nudj/ui/screens/auth/landing/LandingScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/auth/landing/LandingScreen.kt
@@ -1,0 +1,81 @@
+package com.tpc.nudj.ui.screens.auth.landing
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.tpc.nudj.ui.components.PrimaryButton
+import com.tpc.nudj.ui.components.SecondaryButton
+import com.tpc.nudj.ui.theme.ClashDisplay
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
+
+
+@Composable
+fun LandingScreenLayout(){
+    val colors= LocalAppColors.current
+
+    Box(
+        modifier =Modifier
+            .fillMaxSize()
+            .background(colors.landingPageBackground),
+
+    ){
+        Text(
+            text="Nudj",
+            fontFamily = ClashDisplay,
+            fontWeight = FontWeight.SemiBold,
+            fontSize = 110.sp,
+            color = colors.landingPageAppTitle,
+            modifier = Modifier.align(Alignment.Center)
+        )
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(-16.dp),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 120.dp)
+        ){
+            SecondaryButton(
+                text = "Login",
+                onClick = {
+                    //Login Page
+                },
+                enabled = true,
+                isDarkModeEnabled = true
+            )
+
+            PrimaryButton(
+                text = "Sign up",
+                onClick = {
+                    //Sign up
+                },
+                enabled = true,
+                isDarkModeEnabled = true
+
+            )
+        }
+    }
+
+}
+@Preview(showBackground = true, showSystemUi = false)
+@Preview(showBackground = true, showSystemUi = false, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun LandingScreenPreview(){
+    NudjTheme {
+        LandingScreenLayout()
+    }
+}
+
+


### PR DESCRIPTION
# Pull Request – Nudj Contribution


## 🔧 What does this PR do?

- Implements the **Landing Screen** using Jetpack Compose.
- Uses existing `PrimaryButton` and `SecondaryButton` components.
- Applies theme using `LocalAppColors` and `ClashDisplay` font as per project guidelines.

---

## 🧩 Related Issue

Closes: #8

---

## 📸 Screenshots 

- Light Mode preview
- 
![Screenshot 2025-06-12 183258](https://github.com/user-attachments/assets/e70af84b-9c4b-4d1c-8c62-93e3a5f102a6)

- Dark Mode preview
-
![image](https://github.com/user-attachments/assets/17be56bb-1b81-4780-906b-6758562d4390)


---

## ✅ Checklist

- [x] My code follows the project's style and structure  
- [x] I’ve tested my changes locally  
- [x] I’ve not committed any files directly to `main`  

---

## 🧠 Brief Explanation of Approach

- Positioned the title text (`Nudj`) at the center of the screen.
- Placed Login and Sign Up buttons toward the bottom with visual alignment.
- Reused button components without altering them, keeping their internal padding in mind.

---