### PR TITLE
Implemented the Club Profile Screen

### DIFF
--- a/app/src/main/java/com/tpc/nudj/MainActivity.kt
+++ b/app/src/main/java/com/tpc/nudj/MainActivity.kt
@@ -20,7 +20,6 @@ import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.tpc.nudj.ui.navigation.Screens
 import com.tpc.nudj.ui.screens.ClubDashBoard.ClubDashBoardScreen
-import com.tpc.nudj.ui.screens.auth.PreHomeScreen.PreHomeScreen
 import com.tpc.nudj.ui.screens.auth.clubRegistration.ClubRegistrationScreen
 import com.tpc.nudj.ui.screens.auth.detailsInput.DetailsConfirmationScreen
 import com.tpc.nudj.ui.screens.auth.detailsInput.DetailsInputScreen
@@ -28,8 +27,8 @@ import com.tpc.nudj.ui.screens.auth.emailVerification.EmailVerificationScreen
 import com.tpc.nudj.ui.screens.auth.forgotPassword.ForgetPasswordScreen
 import com.tpc.nudj.ui.screens.auth.landing.LandingScreen
 import com.tpc.nudj.ui.screens.auth.login.LoginScreen
+import com.tpc.nudj.ui.screens.auth.preHomeScreen.PreHomeScreen
 import com.tpc.nudj.ui.screens.auth.signup.SignUpScreen
-import com.tpc.nudj.ui.screens.clubDashboard.ClubDashboardScreen
 import com.tpc.nudj.ui.screens.dashboard.DashboardScreen
 import com.tpc.nudj.ui.screens.detailsFetch.UserDetailsFetchScreen
 import com.tpc.nudj.ui.screens.eventDetailsScreen.EventDetailsScreen

--- a/app/src/main/java/com/tpc/nudj/ui/components/TopBar.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/components/TopBar.kt
@@ -1,0 +1,52 @@
+package com.tpc.nudj.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBackIosNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.tpc.nudj.R
+import com.tpc.nudj.ui.theme.ClashDisplay
+import com.tpc.nudj.ui.theme.LocalAppColors
+
+@Composable
+fun TopBar(
+    modifier: Modifier = Modifier,
+    onBackClicked: () -> Unit,
+    haveToGoBack:Boolean = true
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(R.string.app_name),
+            style = MaterialTheme.typography.displayMedium.copy(
+                fontFamily = ClashDisplay,
+                color = LocalAppColors.current.appTitle
+            ),
+            modifier = Modifier.align(Alignment.Center)
+        )
+        if(haveToGoBack) {
+            IconButton(
+                onClick = { onBackClicked() }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBackIosNew,
+                    contentDescription = stringResource(R.string.back_navigation),
+                    modifier = Modifier.size(25.dp),
+                    tint = LocalAppColors.current.appTitle
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screens/ClubDashBoard/ClubDashBoard.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/ClubDashBoard/ClubDashBoard.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tpc.nudj.ui.screens.ClubDashBoard.Data.BottomNavItem
 import com.tpc.nudj.ui.screens.ClubDashBoard.Data.ClubDashBoardScreens
+import com.tpc.nudj.ui.screens.clubProfileScreen.ClubProfileScreen
+import com.tpc.nudj.ui.screens.clubProfileScreen.editClubProfile.EditCLubProfileScreen
 import com.tpc.nudj.ui.theme.EditTextBackgroundColorLight
 import com.tpc.nudj.ui.theme.LocalAppColors
 
@@ -44,7 +46,7 @@ fun ClubDashBoardScreen(
 
     LaunchedEffect(viewModel.selectedPage) {
         if (pagerState.currentPage != viewModel.selectedPage) {
-            delay(150)
+            delay(200)
             pagerState.scrollToPage(viewModel.selectedPage)
         }
     }
@@ -52,7 +54,7 @@ fun ClubDashBoardScreen(
 
     LaunchedEffect(pagerState.currentPage) {
         if (pagerState.currentPage != viewModel.selectedPage) {
-            delay(120)
+            delay(130)
             viewModel.onPageSelected(pagerState.currentPage)
         }
     }
@@ -76,7 +78,7 @@ fun ClubDashBoardScreen(
             when (screens[page]) {
                 is ClubDashBoardScreens.Home -> HomeScreenLayout()
                 is ClubDashBoardScreens.Event -> EventScreenLayout()
-                is ClubDashBoardScreens.Profile -> ProfileScreenLayout()
+                is ClubDashBoardScreens.Profile -> ClubProfileScreen()
             }
         }
     }
@@ -97,7 +99,7 @@ fun ClubBottomNavBar(
         val positionWidth = this.maxWidth / items.size
         val slidingEffect by animateDpAsState(
             targetValue = (selectedIndex * positionWidth.value).dp,
-            animationSpec = tween(durationMillis = 200)
+            animationSpec = tween(durationMillis = 140)
         )
 
         Box(
@@ -180,12 +182,6 @@ fun EventScreenLayout() {
     }
 }
 
-@Composable
-fun ProfileScreenLayout() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text("PROFILE Screen")
-    }
-}
 
 
 

--- a/app/src/main/java/com/tpc/nudj/ui/screens/auth/clubRegistration/ClubRegistrationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/auth/clubRegistration/ClubRegistrationScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.tpc.nudj.R
 import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.ui.components.TopBar
 import com.tpc.nudj.ui.screens.auth.clubRegistration.clubRegistrationScreen1.ClubsRegisterScreen1
 import com.tpc.nudj.ui.screens.auth.clubRegistration.clubRegistrationScreen2.ClubsRegisterScreen2
 import com.tpc.nudj.ui.theme.ClashDisplay
@@ -269,35 +270,6 @@ fun ClubRegistrationLayout(
 }
 
 
-@Composable
-fun TopBar(
-    onBackClicked: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-    ) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.displayMedium.copy(
-                fontFamily = ClashDisplay,
-                color = LocalAppColors.current.appTitle
-            ),
-            modifier = Modifier.align(Alignment.Center)
-        )
-        IconButton(
-            onClick = { onBackClicked() }
-        ) {
-            Icon(
-                imageVector = Icons.Default.ArrowBackIosNew,
-                contentDescription = stringResource(R.string.back_navigation),
-                modifier = Modifier.size(25.dp),
-                tint = LocalAppColors.current.appTitle
-            )
-        }
-    }
-}
 
 @Preview
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileScreen.kt
@@ -170,7 +170,7 @@ fun ClubProfileLayout(
                         ) {
                             Spacer(modifier = Modifier.padding(4.dp))
                             Text(
-                                text = uiState.clubName,
+                                text = if(uiState.clubName!="") uiState.clubName else "Club Name",
                                 style = MaterialTheme.typography.headlineMedium.copy(
                                     fontFamily = ClashDisplay,
                                     color = Color.White
@@ -304,49 +304,51 @@ fun ClubProfileLayout(
                         )
                     }
                     Spacer(modifier = Modifier.padding(4.dp))
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth(0.9f)
-                            .border(
-                                width = 1.8F.dp,
-                                LocalAppColors.current.editTextBorder,
-                                shape = RoundedCornerShape(10.dp)
+                    if (uiState.achievementsList.isNotEmpty()) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth(0.9f)
+                                .border(
+                                    width = 1.8F.dp,
+                                    LocalAppColors.current.editTextBorder,
+                                    shape = RoundedCornerShape(10.dp)
+                                ),
+                            colors = CardDefaults.cardColors(
+                                containerColor = LocalAppColors.current.editTextBackground
                             ),
-                        colors = CardDefaults.cardColors(
-                            containerColor = LocalAppColors.current.editTextBackground
-                        ),
-                    ) {
-                        Spacer(modifier = Modifier.height(16.dp))
-                        uiState.achievementsList.forEach { achievement ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp)
-                            ) {
-                                Text(
-                                    text = "•",
-                                    style = MaterialTheme.typography.titleLarge.copy(
-                                        fontFamily = ClashDisplay,
-                                        color = Orange
-                                    ),
-                                    modifier = Modifier.padding(end = 6.dp)
-                                )
-                                Spacer(modifier = Modifier.width(3.dp))
-                                Text(
-                                    text = achievement,
-                                    style = MaterialTheme.typography.titleLarge.copy(
-                                        fontFamily = ClashDisplay,
-                                        color = Orange
-                                    ),
+                        ) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            uiState.achievementsList.forEach { achievement ->
+                                Row(
                                     modifier = Modifier
-                                        .weight(1f)
-                                        .padding(end = 8.dp),
-                                    textAlign = TextAlign.Start
-                                )
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                ) {
+                                    Text(
+                                        text = "•",
+                                        style = MaterialTheme.typography.titleLarge.copy(
+                                            fontFamily = ClashDisplay,
+                                            color = Orange
+                                        ),
+                                        modifier = Modifier.padding(end = 6.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(3.dp))
+                                    Text(
+                                        text = achievement,
+                                        style = MaterialTheme.typography.titleLarge.copy(
+                                            fontFamily = ClashDisplay,
+                                            color = Orange
+                                        ),
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .padding(end = 8.dp),
+                                        textAlign = TextAlign.Start
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(12.dp))
                             }
-                            Spacer(modifier = Modifier.height(12.dp))
+                            Spacer(modifier = Modifier.height(4.dp))
                         }
-                        Spacer(modifier = Modifier.height(4.dp))
                     }
                     Spacer(modifier = Modifier.padding(6.dp))
                     Row(
@@ -389,8 +391,9 @@ fun ClubProfileLayout(
                                 Text(
                                     text = timestampFormatConverter(eventDetails.eventDate),
                                     style = MaterialTheme.typography.headlineSmall.copy(
+                                        fontSize = (MaterialTheme.typography.headlineSmall.fontSize.value - 2).sp,
                                         fontFamily = ClashDisplay,
-                                        color = LocalAppColors.current.background
+                                        color = LocalAppColors.current.landingPageAppTitle
                                     ),
                                 )
                                 Spacer(modifier = Modifier.padding(12.dp))
@@ -398,7 +401,7 @@ fun ClubProfileLayout(
                                     text = eventDetails.eventName,
                                     style = MaterialTheme.typography.headlineMedium.copy(
                                         fontFamily = ClashDisplay,
-                                        color = LocalAppColors.current.background
+                                        color = LocalAppColors.current.landingPageAppTitle
                                     ),
                                 )
                                 Spacer(modifier = Modifier.padding(10.dp))
@@ -406,7 +409,7 @@ fun ClubProfileLayout(
                                     text = "${eventDetails.rsvp} RSVPs",
                                     style = MaterialTheme.typography.headlineSmall.copy(
                                         fontFamily = ClashDisplay,
-                                        color = LocalAppColors.current.background
+                                        color = LocalAppColors.current.landingPageAppTitle
                                     ),
                                 )
                                 Spacer(modifier = Modifier.padding(10.dp))
@@ -454,7 +457,7 @@ fun ClubProfileLayout(
 }
 
 private fun timestampFormatConverter(eventDate: Timestamp): String {
-    val dateFormatter = SimpleDateFormat("MMMM dd yyyy", Locale.getDefault())
+    val dateFormatter = SimpleDateFormat("dd MMMM yyyy", Locale.getDefault())
     val formattedDate = dateFormatter.format(eventDate.toDate())
     return formattedDate
 }

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileScreen.kt
@@ -1,0 +1,491 @@
+package com.tpc.nudj.ui.screens.clubProfileScreen
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import com.google.firebase.Timestamp
+import com.tpc.nudj.R
+import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.ui.components.LoadingScreenOverlay
+import com.tpc.nudj.ui.components.TopBar
+import com.tpc.nudj.ui.screens.clubProfileScreen.editClubProfile.EditCLubProfileScreen
+import com.tpc.nudj.ui.theme.ClashDisplay
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
+import com.tpc.nudj.ui.theme.Orange
+import com.tpc.nudj.ui.theme.Purple
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+@Composable
+fun ClubProfileScreen(
+    viewModel: ClubProfileViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.profileUiState.collectAsState()
+    var editProfile by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit, editProfile) {
+        viewModel.fetchCurrentClub()
+    }
+    if (uiState.isLoading) {
+        LoadingScreenOverlay()
+    }
+    AnimatedContent(
+        targetState = editProfile,
+        transitionSpec = {
+            slideInHorizontally(
+                initialOffsetX = { fullWidth -> fullWidth },
+                animationSpec = tween(300)
+            ) togetherWith
+                    fadeOut(animationSpec = tween(90))
+        }
+    ) { editScreen ->
+        if (editScreen) {
+            EditCLubProfileScreen(
+                onBackClicked = {
+                    editProfile = false
+                }
+            )
+        } else {
+            ClubProfileLayout(
+                uiState = uiState,
+                onPastEventClicked = {},
+                onEditClicked = {
+                    editProfile = true
+                },
+                clearToastMessage = viewModel::clearToastMessage,
+                clearClubLogo = viewModel::emptyClubLogo
+            )
+        }
+    }
+
+}
+
+@Composable
+fun ClubProfileLayout(
+    uiState: ClubProfileUIState,
+    onPastEventClicked: (String) -> Unit,
+    onEditClicked: () -> Unit,
+    clearToastMessage: () -> Unit,
+    clearClubLogo: () -> Unit
+) {
+    val snackBarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    LaunchedEffect(uiState.toastMessage) {
+        if (uiState.toastMessage != null) {
+            scope.launch {
+                snackBarHostState.showSnackbar(
+                    message = uiState.toastMessage
+                )
+            }
+            clearToastMessage()
+        }
+    }
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackBarHostState) },
+        topBar = {
+            TopBar(
+                onBackClicked = {},
+                modifier = Modifier.padding(top = 20.dp),
+                haveToGoBack = false
+            )
+        },
+        containerColor = LocalAppColors.current.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(LocalAppColors.current.background),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.padding(10.dp))
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(it),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        shape = RoundedCornerShape(20.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = LocalAppColors.current.appTitle
+                        ),
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth(0.9f)
+                                .align(Alignment.CenterHorizontally),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Spacer(modifier = Modifier.padding(4.dp))
+                            Text(
+                                text = uiState.clubName,
+                                style = MaterialTheme.typography.headlineMedium.copy(
+                                    fontFamily = ClashDisplay,
+                                    color = Color.White
+                                ),
+                                textAlign = TextAlign.Center
+                            )
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = uiState.clubCategory.categoryName,
+                                style = MaterialTheme.typography.headlineSmall.copy(
+                                    fontFamily = ClashDisplay,
+                                    color = if (isSystemInDarkTheme()) Purple else Orange
+                                )
+                            )
+                            Spacer(modifier = Modifier.height(3.dp))
+                            if (uiState.clubLogo != null) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                ) {
+
+                                    AsyncImage(
+                                        model = uiState.clubLogo,
+                                        contentDescription = "Club Logo",
+                                        contentScale = ContentScale.Crop,
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clip(RoundedCornerShape(20.dp)),
+                                        onError = {
+                                            clearClubLogo()
+                                        }
+                                    )
+
+                                }
+                            } else {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(140.dp)
+                                        .background(
+                                            Color.LightGray,
+                                            shape = RoundedCornerShape(20.dp)
+                                        ),
+                                    contentAlignment = Alignment.Center
+                                ) {
+
+                                    Image(
+                                        painter = if (isSystemInDarkTheme()) painterResource(R.drawable.purple_n) else painterResource(
+                                            R.drawable.orange_n
+                                        ),
+                                        contentDescription = null
+                                    )
+                                }
+                            }
+                            Spacer(modifier = Modifier.height(6.dp))
+                            Row(
+                                modifier = Modifier
+                                    .clickable {
+                                        onEditClicked()
+                                    }
+                                    .align(Alignment.End)
+                                    .padding(end = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Edit,
+                                    contentDescription = null,
+                                    tint = Color.White
+                                )
+                                Spacer(modifier = Modifier.width(2.dp))
+                                Text(
+                                    text = "Edit",
+                                    style = MaterialTheme.typography.titleLarge.copy(
+                                        color = Color.White,
+                                        fontSize = 20.sp,
+                                        fontFamily = ClashDisplay
+                                    )
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(6.dp))
+                        }
+                    }
+                    Spacer(modifier = Modifier.padding(6.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Description",
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontFamily = ClashDisplay,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        )
+                        Spacer(modifier = Modifier.width(20.dp))
+                        HorizontalDivider(
+                            thickness = 2.dp,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(4.dp))
+                    Box(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = uiState.description,
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontSize = 24.sp,
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(6.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Achievements",
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontFamily = ClashDisplay,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        )
+                        Spacer(modifier = Modifier.width(20.dp))
+                        HorizontalDivider(
+                            thickness = 2.dp,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(4.dp))
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth(0.9f)
+                            .border(
+                                width = 1.8F.dp,
+                                LocalAppColors.current.editTextBorder,
+                                shape = RoundedCornerShape(10.dp)
+                            ),
+                        colors = CardDefaults.cardColors(
+                            containerColor = LocalAppColors.current.editTextBackground
+                        ),
+                    ) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        uiState.achievementsList.forEach { achievement ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp)
+                            ) {
+                                Text(
+                                    text = "•",
+                                    style = MaterialTheme.typography.titleLarge.copy(
+                                        fontFamily = ClashDisplay,
+                                        color = Orange
+                                    ),
+                                    modifier = Modifier.padding(end = 6.dp)
+                                )
+                                Spacer(modifier = Modifier.width(3.dp))
+                                Text(
+                                    text = achievement,
+                                    style = MaterialTheme.typography.titleLarge.copy(
+                                        fontFamily = ClashDisplay,
+                                        color = Orange
+                                    ),
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(end = 8.dp),
+                                    textAlign = TextAlign.Start
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
+                    Spacer(modifier = Modifier.padding(6.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Past Events",
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontFamily = ClashDisplay,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        )
+                        Spacer(modifier = Modifier.width(20.dp))
+                        HorizontalDivider(
+                            thickness = 2.dp,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(4.dp))
+                    uiState.clubEvents.forEach { eventDetails ->
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth(0.9f)
+                                .clickable {
+                                    onPastEventClicked(eventDetails.eventId)
+                                },
+                            shape = RoundedCornerShape(20.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = LocalAppColors.current.appTitle
+                            ),
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth(0.9f)
+                                    .align(Alignment.CenterHorizontally),
+                                horizontalAlignment = Alignment.Start,
+                            ) {
+                                Spacer(modifier = Modifier.padding(6.dp))
+                                Text(
+                                    text = timestampFormatConverter(eventDetails.eventDate),
+                                    style = MaterialTheme.typography.headlineSmall.copy(
+                                        fontFamily = ClashDisplay,
+                                        color = LocalAppColors.current.background
+                                    ),
+                                )
+                                Spacer(modifier = Modifier.padding(12.dp))
+                                Text(
+                                    text = eventDetails.eventName,
+                                    style = MaterialTheme.typography.headlineMedium.copy(
+                                        fontFamily = ClashDisplay,
+                                        color = LocalAppColors.current.background
+                                    ),
+                                )
+                                Spacer(modifier = Modifier.padding(10.dp))
+                                Text(
+                                    text = "${eventDetails.rsvp} RSVPs",
+                                    style = MaterialTheme.typography.headlineSmall.copy(
+                                        fontFamily = ClashDisplay,
+                                        color = LocalAppColors.current.background
+                                    ),
+                                )
+                                Spacer(modifier = Modifier.padding(10.dp))
+                            }
+                        }
+                        Spacer(modifier = Modifier.padding(8.dp))
+                    }
+                    Spacer(modifier = Modifier.padding(6.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Additional Details",
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontFamily = ClashDisplay,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        )
+                        Spacer(modifier = Modifier.width(20.dp))
+                        HorizontalDivider(
+                            thickness = 2.dp,
+                            color = MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(4.dp))
+                    Box(
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = uiState.additionalDetails,
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontSize = 24.sp,
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                    }
+                }
+            }
+
+        }
+    }
+}
+
+private fun timestampFormatConverter(eventDate: Timestamp): String {
+    val dateFormatter = SimpleDateFormat("MMMM dd yyyy", Locale.getDefault())
+    val formattedDate = dateFormatter.format(eventDate.toDate())
+    return formattedDate
+}
+
+
+@Preview
+@Composable
+fun ClubProfileScreenPreview() {
+    NudjTheme {
+        ClubProfileLayout(
+            uiState = ClubProfileUIState(
+                clubName = "The Programming Club",
+                clubCategory = ClubCategory.TECHNICAL,
+                description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In sapien enim, blandit eget tellus in ultrices iaculis felis. In turpis mauris, ",
+                achievementsList = listOf(
+                    "Achievement 1",
+                    "Achievement 2",
+                    "Achievement 3",
+                    "Achievement 4"
+                ),
+                clubEvents = listOf(
+                    PastEventsDetails(
+                        rsvp = 10,
+                        eventDate = Timestamp.now()
+                    )
+                )
+            ),
+            onPastEventClicked = {},
+            onEditClicked = {},
+            clearToastMessage = {},
+            clearClubLogo = {}
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileScreen.kt
@@ -170,7 +170,7 @@ fun ClubProfileLayout(
                         ) {
                             Spacer(modifier = Modifier.padding(4.dp))
                             Text(
-                                text = if(uiState.clubName!="") uiState.clubName else "Club Name",
+                                text = if (uiState.clubName != "") uiState.clubName else "Club Name",
                                 style = MaterialTheme.typography.headlineMedium.copy(
                                     fontFamily = ClashDisplay,
                                     color = Color.White
@@ -254,57 +254,59 @@ fun ClubProfileLayout(
                         }
                     }
                     Spacer(modifier = Modifier.padding(6.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(0.9f),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Description",
-                            style = MaterialTheme.typography.headlineMedium.copy(
-                                fontFamily = ClashDisplay,
+                    if (uiState.description.isNotEmpty()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(0.9f),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Description",
+                                style = MaterialTheme.typography.headlineMedium.copy(
+                                    fontFamily = ClashDisplay,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                            )
+                            Spacer(modifier = Modifier.width(20.dp))
+                            HorizontalDivider(
+                                thickness = 2.dp,
                                 color = MaterialTheme.colorScheme.onBackground
                             )
-                        )
-                        Spacer(modifier = Modifier.width(20.dp))
-                        HorizontalDivider(
-                            thickness = 2.dp,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    }
-                    Spacer(modifier = Modifier.padding(4.dp))
-                    Box(
-                        modifier = Modifier.fillMaxWidth(0.9f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = uiState.description,
-                            style = MaterialTheme.typography.titleMedium.copy(
-                                fontSize = 24.sp,
-                                fontFamily = ClashDisplay,
-                                color = Orange
-                            ),
-                        )
-                    }
-                    Spacer(modifier = Modifier.padding(6.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(0.9f),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Achievements",
-                            style = MaterialTheme.typography.headlineMedium.copy(
-                                fontFamily = ClashDisplay,
-                                color = MaterialTheme.colorScheme.onBackground
+                        }
+                        Spacer(modifier = Modifier.padding(4.dp))
+                        Box(
+                            modifier = Modifier.fillMaxWidth(0.9f),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = uiState.description,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontSize = 24.sp,
+                                    fontFamily = ClashDisplay,
+                                    color = Orange
+                                ),
                             )
-                        )
-                        Spacer(modifier = Modifier.width(20.dp))
-                        HorizontalDivider(
-                            thickness = 2.dp,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
+                        }
+                        Spacer(modifier = Modifier.padding(6.dp))
                     }
-                    Spacer(modifier = Modifier.padding(4.dp))
                     if (uiState.achievementsList.isNotEmpty()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(0.9f),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Achievements",
+                                style = MaterialTheme.typography.headlineMedium.copy(
+                                    fontFamily = ClashDisplay,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                            )
+                            Spacer(modifier = Modifier.width(20.dp))
+                            HorizontalDivider(
+                                thickness = 2.dp,
+                                color = MaterialTheme.colorScheme.onBackground
+                            )
+                        }
+                        Spacer(modifier = Modifier.padding(4.dp))
                         Card(
                             modifier = Modifier
                                 .fillMaxWidth(0.9f)
@@ -351,103 +353,107 @@ fun ClubProfileLayout(
                         }
                     }
                     Spacer(modifier = Modifier.padding(6.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(0.9f),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Past Events",
-                            style = MaterialTheme.typography.headlineMedium.copy(
-                                fontFamily = ClashDisplay,
+                    if(uiState.clubEvents.isNotEmpty()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(0.9f),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Past Events",
+                                style = MaterialTheme.typography.headlineMedium.copy(
+                                    fontFamily = ClashDisplay,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                            )
+                            Spacer(modifier = Modifier.width(20.dp))
+                            HorizontalDivider(
+                                thickness = 2.dp,
                                 color = MaterialTheme.colorScheme.onBackground
                             )
-                        )
-                        Spacer(modifier = Modifier.width(20.dp))
-                        HorizontalDivider(
-                            thickness = 2.dp,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    }
-                    Spacer(modifier = Modifier.padding(4.dp))
-                    uiState.clubEvents.forEach { eventDetails ->
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth(0.9f)
-                                .clickable {
-                                    onPastEventClicked(eventDetails.eventId)
-                                },
-                            shape = RoundedCornerShape(20.dp),
-                            colors = CardDefaults.cardColors(
-                                containerColor = LocalAppColors.current.appTitle
-                            ),
-                        ) {
-                            Column(
+                        }
+                        Spacer(modifier = Modifier.padding(4.dp))
+                        uiState.clubEvents.forEach { eventDetails ->
+                            Card(
                                 modifier = Modifier
                                     .fillMaxWidth(0.9f)
-                                    .align(Alignment.CenterHorizontally),
-                                horizontalAlignment = Alignment.Start,
+                                    .clickable {
+                                        onPastEventClicked(eventDetails.eventId)
+                                    },
+                                shape = RoundedCornerShape(20.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = LocalAppColors.current.appTitle
+                                ),
                             ) {
-                                Spacer(modifier = Modifier.padding(6.dp))
-                                Text(
-                                    text = timestampFormatConverter(eventDetails.eventDate),
-                                    style = MaterialTheme.typography.headlineSmall.copy(
-                                        fontSize = (MaterialTheme.typography.headlineSmall.fontSize.value - 2).sp,
-                                        fontFamily = ClashDisplay,
-                                        color = LocalAppColors.current.landingPageAppTitle
-                                    ),
-                                )
-                                Spacer(modifier = Modifier.padding(12.dp))
-                                Text(
-                                    text = eventDetails.eventName,
-                                    style = MaterialTheme.typography.headlineMedium.copy(
-                                        fontFamily = ClashDisplay,
-                                        color = LocalAppColors.current.landingPageAppTitle
-                                    ),
-                                )
-                                Spacer(modifier = Modifier.padding(10.dp))
-                                Text(
-                                    text = "${eventDetails.rsvp} RSVPs",
-                                    style = MaterialTheme.typography.headlineSmall.copy(
-                                        fontFamily = ClashDisplay,
-                                        color = LocalAppColors.current.landingPageAppTitle
-                                    ),
-                                )
-                                Spacer(modifier = Modifier.padding(10.dp))
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth(0.9f)
+                                        .align(Alignment.CenterHorizontally),
+                                    horizontalAlignment = Alignment.Start,
+                                ) {
+                                    Spacer(modifier = Modifier.padding(6.dp))
+                                    Text(
+                                        text = timestampFormatConverter(eventDetails.eventDate),
+                                        style = MaterialTheme.typography.headlineSmall.copy(
+                                            fontSize = (MaterialTheme.typography.headlineSmall.fontSize.value - 2).sp,
+                                            fontFamily = ClashDisplay,
+                                            color = LocalAppColors.current.landingPageAppTitle
+                                        ),
+                                    )
+                                    Spacer(modifier = Modifier.padding(12.dp))
+                                    Text(
+                                        text = eventDetails.eventName,
+                                        style = MaterialTheme.typography.headlineMedium.copy(
+                                            fontFamily = ClashDisplay,
+                                            color = LocalAppColors.current.landingPageAppTitle
+                                        ),
+                                    )
+                                    Spacer(modifier = Modifier.padding(10.dp))
+                                    Text(
+                                        text = "${eventDetails.rsvp} RSVPs",
+                                        style = MaterialTheme.typography.headlineSmall.copy(
+                                            fontFamily = ClashDisplay,
+                                            color = LocalAppColors.current.landingPageAppTitle
+                                        ),
+                                    )
+                                    Spacer(modifier = Modifier.padding(10.dp))
+                                }
                             }
+                            Spacer(modifier = Modifier.padding(8.dp))
                         }
-                        Spacer(modifier = Modifier.padding(8.dp))
+                        Spacer(modifier = Modifier.padding(6.dp))
                     }
-                    Spacer(modifier = Modifier.padding(6.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(0.9f),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "Additional Details",
-                            style = MaterialTheme.typography.headlineMedium.copy(
-                                fontFamily = ClashDisplay,
+                    if(uiState.additionalDetails.isNotEmpty()) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(0.9f),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Additional Details",
+                                style = MaterialTheme.typography.headlineMedium.copy(
+                                    fontFamily = ClashDisplay,
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
+                            )
+                            Spacer(modifier = Modifier.width(20.dp))
+                            HorizontalDivider(
+                                thickness = 2.dp,
                                 color = MaterialTheme.colorScheme.onBackground
                             )
-                        )
-                        Spacer(modifier = Modifier.width(20.dp))
-                        HorizontalDivider(
-                            thickness = 2.dp,
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    }
-                    Spacer(modifier = Modifier.padding(4.dp))
-                    Box(
-                        modifier = Modifier.fillMaxWidth(0.9f),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = uiState.additionalDetails,
-                            style = MaterialTheme.typography.titleMedium.copy(
-                                fontSize = 24.sp,
-                                fontFamily = ClashDisplay,
-                                color = Orange
-                            ),
-                        )
+                        }
+                        Spacer(modifier = Modifier.padding(4.dp))
+                        Box(
+                            modifier = Modifier.fillMaxWidth(0.9f),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = uiState.additionalDetails,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontSize = 24.sp,
+                                    fontFamily = ClashDisplay,
+                                    color = Orange
+                                ),
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileUIState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileUIState.kt
@@ -1,0 +1,26 @@
+package com.tpc.nudj.ui.screens.clubProfileScreen
+
+import com.google.firebase.Timestamp
+import com.tpc.nudj.model.RSVP
+import com.tpc.nudj.model.enums.ClubCategory
+
+data class ClubProfileUIState(
+    val clubName: String = "",
+    val clubCategory: ClubCategory = ClubCategory.MISCELLANEOUS,
+    val description: String = "",
+    val achievementsList: List<String> = emptyList(),
+    val clubLogo:String?=null,
+    val tempClubLogo:String?=null,
+    val clubEvents:List<PastEventsDetails> = emptyList(),
+    val additionalDetails:String = "",
+    val isLoading:Boolean = false,
+    val toastMessage:String?=null,
+)
+
+
+data class PastEventsDetails(
+    val eventId:String="",
+    val eventDate: Timestamp = Timestamp.now(),
+    val eventName:String = "",
+    val rsvp: Int = 0
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/ClubProfileViewModel.kt
@@ -1,0 +1,134 @@
+package com.tpc.nudj.ui.screens.clubProfileScreen
+
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.tpc.nudj.repository.events.EventsRepository
+import com.tpc.nudj.repository.user.UserRepository
+import com.tpc.nudj.ui.BaseViewModel
+import com.tpc.nudj.utils.FirestoreCollections
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+@HiltViewModel
+class ClubProfileViewModel @Inject constructor(
+    val userRepository: UserRepository,
+    val eventRepository: EventsRepository,
+) : BaseViewModel<ClubProfileUIState>() {
+    private val _uiState = MutableStateFlow(ClubProfileUIState())
+    val profileUiState: StateFlow<ClubProfileUIState> = _uiState.asStateFlow()
+
+    override val uiState: StateFlow<ClubProfileUIState>
+        get() = profileUiState
+
+    override fun createUiStateFlow(): StateFlow<ClubProfileUIState> {
+        return _uiState.asStateFlow()
+    }
+
+    init {
+        _uiState.update {
+            it.copy(
+                isLoading = true
+            )
+        }
+        viewModelScope.launch {
+            errorFlow.collect { error ->
+                _uiState.update {
+                    it.copy(toastMessage = error)
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            successMsgFlow.collect { msg ->
+                _uiState.update {
+                    it.copy(toastMessage = msg)
+                }
+            }
+        }
+    }
+
+    fun clearToastMessage() {
+        clearMsgFlow()
+        clearErrorFlow()
+    }
+
+    fun fetchCurrentClub() {
+        viewModelScope.launch {
+            val currentUserId = FirebaseAuth.getInstance().currentUser?.uid
+            if (currentUserId == null) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                    )
+                }
+                emitError("No user found!!")
+                return@launch
+            }
+            val clubDetails = userRepository.fetchCurrentClub()
+            if (clubDetails == null) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                    )
+                }
+                emitError("No user details found!!")
+                return@launch
+            }
+            val pastEvents = fetchPastEvents(currentUserId)
+            _uiState.update {
+                it.copy(
+                    clubName = clubDetails.clubName,
+                    clubCategory = clubDetails.clubCategory,
+                    description = clubDetails.description,
+                    achievementsList = clubDetails.achievementsList,
+                    clubLogo = clubDetails.clubLogo,
+                    tempClubLogo = clubDetails.clubLogo,
+                    additionalDetails = clubDetails.additionalDetails,
+                    clubEvents = pastEvents,
+                    isLoading = false
+                )
+            }
+        }
+    }
+
+    fun emptyClubLogo() {
+        _uiState.update {
+            it.copy(
+                clubLogo = null
+            )
+        }
+    }
+
+
+    suspend fun fetchPastEvents(currentUserId: String): List<PastEventsDetails> {
+        val firestore = FirebaseFirestore.getInstance()
+        val allEvents = eventRepository.fetchAllEvents().filter {
+            it.clubId == currentUserId &&
+                    it.eventDates.firstOrNull()?.startDateTime?.toDate()
+                        ?.before(Timestamp.now().toDate()) == true
+        }
+
+        return allEvents.map { event ->
+            val clubEvent = firestore.collection(FirestoreCollections.RSVP.path)
+                .whereEqualTo("eventId", event.eventId)
+                .get()
+                .await()
+            val rsvpCount = clubEvent.size()
+            PastEventsDetails(
+                eventId = event.eventId,
+                eventName = event.eventName,
+                eventDate = event.eventDates.first().startDateTime,
+                rsvp = rsvpCount
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/editClubProfile/EditClubProfileScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/editClubProfile/EditClubProfileScreen.kt
@@ -1,0 +1,613 @@
+package com.tpc.nudj.ui.screens.clubProfileScreen.editClubProfile
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.tpc.nudj.R
+import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.ui.components.LoadingScreenOverlay
+import com.tpc.nudj.ui.components.NudjTextField
+import com.tpc.nudj.ui.components.TopBar
+import com.tpc.nudj.ui.theme.ClashDisplay
+import com.tpc.nudj.ui.theme.LocalAppColors
+import com.tpc.nudj.ui.theme.NudjTheme
+import com.tpc.nudj.ui.theme.Orange
+import kotlinx.coroutines.launch
+
+@Composable
+fun EditCLubProfileScreen(
+    viewModel: EditClubProfileViewModel = hiltViewModel(),
+    onBackClicked: () -> Unit
+) {
+    val uiState by viewModel.profileUiState.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.fetchCurrentClub()
+    }
+    EditClubProfileLayout(
+        uiState = uiState,
+        onNameInput = viewModel::clubNameInput,
+        onImagePicked = viewModel::clubLogoImageInput,
+        onBackClicked = {
+            onBackClicked()
+        },
+        onRemoveAchievement = viewModel::removeAchievement,
+        onCategoryInput = viewModel::clubCategoryInput,
+        onAddAchievement = viewModel::addAchievement,
+        onDescriptionInput = viewModel::clubDescriptionInput,
+        onAdditionalDetailsInput = viewModel::clubAdditionalDetailsInput,
+        clearToastMessage = viewModel::clearToastMessage,
+        removeTempClubLogo = viewModel::emptyTempClubLogo,
+        onSaveClicked = {
+            viewModel.onSaveClicked(
+                toClubProfileScreen = {
+                    onBackClicked()
+                }
+            )
+        }
+    )
+    if (uiState.isLoading) {
+        LoadingScreenOverlay()
+    }
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditClubProfileLayout(
+    uiState: EditClubProfileUIState,
+    onNameInput: (String) -> Unit,
+    onCategoryInput: (ClubCategory) -> Unit,
+    onDescriptionInput: (String) -> Unit,
+    onAddAchievement: (String) -> Unit,
+    onRemoveAchievement: (Int) -> Unit,
+    clearToastMessage: () -> Unit,
+    onBackClicked: () -> Unit,
+    onImagePicked: (Uri?) -> Unit,
+    onAdditionalDetailsInput: (String) -> Unit,
+    onSaveClicked: () -> Unit,
+    removeTempClubLogo: () -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val categoryList = ClubCategory.entries.toList()
+    var achievementInput by remember { mutableStateOf("") }
+    val focusManager = LocalFocusManager.current
+    val scope = rememberCoroutineScope()
+    val snackBarHostState = remember { SnackbarHostState() }
+
+
+    LaunchedEffect(uiState.toastMessage) {
+        if (uiState.toastMessage != null) {
+            scope.launch {
+                snackBarHostState.showSnackbar(
+                    message = uiState.toastMessage
+                )
+            }
+            clearToastMessage()
+        }
+    }
+
+    var imageUri by remember { mutableStateOf<Uri?>(null) }
+
+    LaunchedEffect(uiState.tempClubLogo) {
+        imageUri = uiState.tempClubLogo?.toUri()
+    }
+
+    val pickImageLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+        onResult = { uri ->
+            imageUri = uri
+            onImagePicked(uri)
+        }
+    )
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackBarHostState) },
+        topBar = {
+            TopBar(
+                onBackClicked = {
+                    onBackClicked()
+                },
+                modifier = Modifier.padding(top = 20.dp)
+            )
+        },
+        containerColor = LocalAppColors.current.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(LocalAppColors.current.background),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.padding(10.dp))
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(LocalAppColors.current.background)
+                    .padding(it),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 44.dp)
+                    ) {
+                        Text(
+                            text = "Club Name",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                        NudjTextField(
+                            value = uiState.tempClubName,
+                            onValueChange = { onNameInput(it) },
+                            singleLine = true,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .border(
+                                    width = 1.8F.dp,
+                                    LocalAppColors.current.editTextBorder,
+                                    shape = RoundedCornerShape(16.dp)
+                                )
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(10.dp))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 44.dp)
+                    ) {
+                        Text(
+                            text = "Category",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                        ExposedDropdownMenuBox(
+                            expanded = expanded,
+                            onExpandedChange = {
+                                expanded = !expanded
+                            }
+                        ) {
+                            NudjTextField(
+                                value = uiState.tempClubCategory.categoryName,
+                                onValueChange = {},
+                                singleLine = true,
+                                readOnly = true,
+                                trailingIcon = {
+                                    Image(
+                                        painter = painterResource(R.drawable.dropdownicon),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(45.dp)
+                                    )
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .menuAnchor()
+                                    .border(
+                                        width = 1.8F.dp,
+                                        LocalAppColors.current.editTextBorder,
+                                        shape = RoundedCornerShape(16.dp)
+                                    )
+                            )
+                            ExposedDropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false },
+                                modifier = Modifier.background(LocalAppColors.current.editTextBackground)
+                            ) {
+                                categoryList.forEach { category ->
+                                    DropdownMenuItem(
+                                        text = {
+                                            Text(
+                                                text = category.categoryName,
+                                                style = MaterialTheme.typography.titleMedium.copy(
+                                                    fontFamily = ClashDisplay
+                                                )
+                                            )
+                                        },
+                                        onClick = {
+                                            onCategoryInput(category)
+                                            expanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.padding(10.dp))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 44.dp)
+                    ) {
+                        Text(
+                            text = "Description",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                        NudjTextField(
+                            value = uiState.tempDescription,
+                            onValueChange = { onDescriptionInput(it) },
+                            singleLine = false,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .border(
+                                    width = 1.8F.dp,
+                                    LocalAppColors.current.editTextBorder,
+                                    shape = RoundedCornerShape(16.dp)
+                                )
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(10.dp))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 44.dp)
+                    ) {
+                        Text(
+                            text = "Achievements",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            NudjTextField(
+                                value = achievementInput,
+                                onValueChange = { achievementInput = it },
+                                singleLine = false,
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .border(
+                                        width = 1.8F.dp,
+                                        LocalAppColors.current.editTextBorder,
+                                        shape = RoundedCornerShape(16.dp)
+                                    )
+                            )
+                            Spacer(modifier = Modifier.width(10.dp))
+                            IconButton(
+                                modifier = Modifier.size(60.dp),
+                                onClick = {
+                                    onAddAchievement(achievementInput)
+                                    achievementInput = ""
+                                    focusManager.clearFocus()
+                                },
+                                colors = IconButtonDefaults.iconButtonColors(
+                                    containerColor = Orange
+                                )
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Add,
+                                    contentDescription = "Add achievement",
+                                    tint = Color.White,
+                                    modifier = Modifier.size(40.dp)
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.padding(10.dp))
+                        uiState.tempAchievementsList.forEachIndexed { index, achievement ->
+                            val visible = remember { mutableStateOf(false) }
+
+                            LaunchedEffect(Unit) {
+                                visible.value = true
+                            }
+
+                            AnimatedVisibility(
+                                visible = visible.value,
+                                enter = slideInHorizontally(initialOffsetX = { -it }) + fadeIn(),
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 6.dp)
+                                ) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 4.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text(
+                                            text = "•",
+                                            style = MaterialTheme.typography.titleLarge.copy(
+                                                fontFamily = ClashDisplay,
+                                                color = Orange
+                                            ),
+                                            modifier = Modifier.padding(end = 6.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(3.dp))
+                                        Text(
+                                            text = achievement,
+                                            style = MaterialTheme.typography.titleLarge.copy(
+                                                fontFamily = ClashDisplay,
+                                                color = Orange
+                                            ),
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .padding(end = 8.dp),
+                                            textAlign = TextAlign.Start
+                                        )
+
+                                        IconButton(
+                                            onClick = { onRemoveAchievement(index) },
+                                            modifier = Modifier.size(36.dp)
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Delete,
+                                                contentDescription = "Delete the achievement",
+                                                tint = Orange,
+                                                modifier = Modifier.size(24.dp)
+                                            )
+                                        }
+                                    }
+
+                                    Spacer(modifier = Modifier.height(4.dp))
+
+                                    HorizontalDivider(
+                                        thickness = 1.dp,
+                                        color = Orange,
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                }
+                            }
+
+                        }
+                    }
+                    Spacer(modifier = Modifier.padding(10.dp))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 44.dp)
+                    ) {
+                        Text(
+                            text = "Club Logo",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                        Card(
+                            modifier = Modifier
+                                .border(
+                                    width = 1.8F.dp,
+                                    LocalAppColors.current.editTextBorder,
+                                    shape = RoundedCornerShape(16.dp)
+                                ),
+                            colors = CardDefaults.cardColors(
+                                containerColor = LocalAppColors.current.editTextBackground
+                            )
+                        ) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                            ) {
+                                if (imageUri == null) {
+                                    Box(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Image(
+                                            painter = if (isSystemInDarkTheme()) painterResource(R.drawable.frame3light) else painterResource(
+                                                R.drawable.frame3
+                                            ),
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(16.dp)
+                                        )
+                                        Column(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalAlignment = Alignment.CenterHorizontally
+                                        ) {
+                                            Text(
+                                                text = "Club Logo",
+                                                style = MaterialTheme.typography.titleLarge.copy(
+                                                    fontFamily = ClashDisplay,
+                                                    color = MaterialTheme.colorScheme.onBackground
+                                                )
+                                            )
+                                            Spacer(modifier = Modifier.padding(20.dp))
+                                            Button(
+                                                modifier = Modifier,
+                                                onClick = {
+                                                    pickImageLauncher.launch(
+                                                        PickVisualMediaRequest(
+                                                            ActivityResultContracts.PickVisualMedia.ImageOnly
+                                                        )
+                                                    )
+                                                },
+                                                colors = ButtonDefaults.buttonColors(
+                                                    containerColor = Orange
+                                                ),
+                                                shape = RoundedCornerShape(10.dp)
+                                            ) {
+                                                Text(
+                                                    text = "Upload",
+                                                    style = MaterialTheme.typography.titleMedium.copy(
+                                                        fontFamily = ClashDisplay,
+                                                        color = Color.White
+                                                    ),
+                                                    modifier = Modifier.padding(vertical = 2.dp)
+                                                )
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .padding(16.dp),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        AsyncImage(
+                                            model = ImageRequest.Builder(context = LocalContext.current)
+                                                .data(imageUri)
+                                                .crossfade(true)
+                                                .build(),
+                                            contentDescription = "club logo",
+                                            contentScale = ContentScale.Crop
+                                        )
+                                    }
+                                }
+                                if (imageUri != null) {
+                                    IconButton(
+                                        onClick = {
+                                            imageUri = null
+                                            removeTempClubLogo()
+                                        },
+                                        colors = IconButtonDefaults.filledIconButtonColors(
+                                            containerColor = Orange,
+                                        ),
+                                        modifier = Modifier.align(Alignment.TopEnd)
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.Close,
+                                            contentDescription = "cancel the image selection",
+                                            tint = Color.White,
+                                            modifier = Modifier.size(23.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.padding(10.dp))
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 44.dp)
+                    ) {
+                        Text(
+                            text = "Additional Details",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Orange
+                            ),
+                        )
+                        NudjTextField(
+                            value = uiState.tempAdditionalDetails,
+                            onValueChange = { onAdditionalDetailsInput(it) },
+                            singleLine = false,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .border(
+                                    width = 1.8F.dp,
+                                    LocalAppColors.current.editTextBorder,
+                                    shape = RoundedCornerShape(16.dp)
+                                )
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(20.dp))
+                    Button(
+                        onClick = {
+                            onSaveClicked()
+                        },
+                        modifier = Modifier.fillMaxWidth(0.7f),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Orange
+                        )
+                    ) {
+                        Text(
+                            text = "Save",
+                            style = MaterialTheme.typography.titleLarge.copy(
+                                fontFamily = ClashDisplay,
+                                color = Color.White
+                            ),
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.padding(10.dp))
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun EditClubProfilePreview() {
+    NudjTheme {
+        EditClubProfileLayout(
+            uiState = EditClubProfileUIState(),
+            onBackClicked = {},
+            onNameInput = {},
+            onDescriptionInput = {},
+            onCategoryInput = {},
+            onAddAchievement = {},
+            onRemoveAchievement = {},
+            clearToastMessage = {},
+            onImagePicked = {},
+            onAdditionalDetailsInput = {},
+            onSaveClicked = {},
+            removeTempClubLogo = {}
+        )
+    }
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/editClubProfile/EditClubProfileUIState.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/editClubProfile/EditClubProfileUIState.kt
@@ -1,0 +1,17 @@
+package com.tpc.nudj.ui.screens.clubProfileScreen.editClubProfile
+
+import com.google.firebase.Timestamp
+import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.ui.screens.clubProfileScreen.PastEventsDetails
+
+data class EditClubProfileUIState(
+    val tempClubName: String = "",
+    val tempClubCategory: ClubCategory = ClubCategory.MISCELLANEOUS,
+    val tempDescription: String = "",
+    val tempAchievementsList: List<String> = emptyList(),
+    val tempClubLogo:String?=null,
+    val tempClubEvents:List<PastEventsDetails> = emptyList(),
+    val tempAdditionalDetails:String = "",
+    val isLoading:Boolean = false,
+    val toastMessage:String?=null,
+)

--- a/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/editClubProfile/EditClubProfileViewModel.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/clubProfileScreen/editClubProfile/EditClubProfileViewModel.kt
@@ -1,0 +1,227 @@
+package com.tpc.nudj.ui.screens.clubProfileScreen.editClubProfile
+
+import android.net.Uri
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.tpc.nudj.model.ClubUser
+import com.tpc.nudj.model.enums.ClubCategory
+import com.tpc.nudj.repository.user.UserRepository
+import com.tpc.nudj.ui.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class EditClubProfileViewModel @Inject constructor(
+    val userRepository: UserRepository
+) : BaseViewModel<EditClubProfileUIState>() {
+    private val _uiState = MutableStateFlow(EditClubProfileUIState())
+    val profileUiState: StateFlow<EditClubProfileUIState> = _uiState.asStateFlow()
+
+    override val uiState: StateFlow<EditClubProfileUIState>
+        get() = profileUiState
+
+    override fun createUiStateFlow(): StateFlow<EditClubProfileUIState> {
+        return _uiState.asStateFlow()
+    }
+
+    init {
+        viewModelScope.launch {
+            errorFlow.collect { error ->
+                _uiState.update {
+                    it.copy(toastMessage = error)
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            successMsgFlow.collect { msg ->
+                _uiState.update {
+                    it.copy(toastMessage = msg)
+                }
+            }
+        }
+    }
+
+    fun clearToastMessage() {
+        clearMsgFlow()
+        clearErrorFlow()
+    }
+
+    fun clubNameInput(input: String) {
+        _uiState.update {
+            it.copy(
+                tempClubName = input
+            )
+        }
+    }
+
+
+    fun clubCategoryInput(input: ClubCategory) {
+        _uiState.update {
+            it.copy(
+                tempClubCategory = input
+            )
+        }
+    }
+
+    fun clubDescriptionInput(input: String) {
+
+        _uiState.update {
+            it.copy(
+                tempDescription = input
+            )
+        }
+    }
+
+    fun addAchievement(input: String) {
+        if (input.isNotBlank()) {
+            _uiState.update {
+                it.copy(tempAchievementsList = it.tempAchievementsList + input.trim())
+            }
+        }
+    }
+
+    fun removeAchievement(index: Int) {
+        _uiState.update {
+            val updatedList = it.tempAchievementsList.toMutableList().apply {
+                removeAt(index)
+            }
+            it.copy(
+                tempAchievementsList = updatedList
+            )
+        }
+    }
+
+    fun clubLogoImageInput(uri: Uri?) {
+        _uiState.update {
+            it.copy(
+                tempClubLogo = uri.toString()  //  For now just storing the uri in string format in the ClubLogo
+            )
+        }
+    }
+
+    fun clubAdditionalDetailsInput(input: String) {
+        _uiState.update {
+            it.copy(
+                tempAdditionalDetails = input
+            )
+        }
+    }
+
+    fun emptyTempClubLogo() {
+        _uiState.update {
+            it.copy(
+                tempClubLogo = null
+            )
+        }
+    }
+
+    suspend fun fetchCurrentClub() {
+        _uiState.update {
+            it.copy(
+                isLoading = true
+            )
+        }
+        val clubDetails = userRepository.fetchCurrentClub()
+        if (clubDetails == null) {
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                )
+            }
+            emitError("No user found!!")
+            return
+        }
+        _uiState.update {
+            it.copy(
+                tempClubName = clubDetails.clubName,
+                tempClubCategory = clubDetails.clubCategory,
+                tempDescription = clubDetails.description,
+                tempAchievementsList = clubDetails.achievementsList,
+                tempClubLogo = clubDetails.clubLogo,
+                tempAdditionalDetails = clubDetails.additionalDetails
+            )
+        }
+        _uiState.update {
+            it.copy(
+                isLoading = false
+            )
+        }
+    }
+
+
+    fun onSaveClicked(toClubProfileScreen: () -> Unit) {
+        val firebase = FirebaseAuth.getInstance()
+        val clubName = _uiState.value.tempClubName
+        val clubEmail = firebase.currentUser?.email
+        val clubCategory = _uiState.value.tempClubCategory
+        val clubLogo = _uiState.value.tempClubLogo
+        val clubDescription = _uiState.value.tempDescription
+        val clubAchievementsList = _uiState.value.tempAchievementsList
+        val clubAdditionalDetails = _uiState.value.tempAdditionalDetails
+
+        when {
+            clubEmail.isNullOrBlank() -> {
+                emitError("No user email found.")
+                return
+            }
+
+            clubName.isBlank() -> {
+                emitError("Club name cannot be empty.")
+                return
+            }
+
+            clubLogo.isNullOrBlank() -> {
+                emitError("Please upload a club logo.")
+                return
+            }
+
+            clubDescription.isBlank() -> {
+                emitError("Club description cannot be empty.")
+                return
+            }
+        }
+        _uiState.update {
+            it.copy(
+                isLoading = true,
+            )
+        }
+        clearErrorFlow()
+        clearMsgFlow()
+        viewModelScope.launch {
+            try {
+                val clubId = firebase.currentUser?.uid ?: throw IllegalStateException("User not logged in")
+                val clubDetails = ClubUser(
+                    clubId = clubId,
+                    clubName = clubName,
+                    clubEmail = clubEmail,
+                    clubCategory = clubCategory,
+                    clubLogo = clubLogo,
+                    description = clubDescription,
+                    achievementsList = clubAchievementsList,
+                    additionalDetails = clubAdditionalDetails
+                )
+                userRepository.saveClub(clubDetails)
+                _uiState.update {
+                    it.copy(
+                        isLoading = false
+                    )
+                }
+                viewModelScope.launch {
+                    emitMsg("Club details saved Successfully!!")
+                    delay(500)
+                    toClubProfileScreen()
+                }
+            } catch (e: Exception) {
+                emitError("Failed to save club details, please try again")
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/tpc/nudj/ui/screens/dashboard/announcement/AnnouncementScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/dashboard/announcement/AnnouncementScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.TopBar
 import com.tpc.nudj.ui.theme.ClashDisplay
 import com.tpc.nudj.ui.theme.EditTextBackgroundColorLight
 import com.tpc.nudj.ui.theme.LocalAppColors
@@ -148,35 +149,6 @@ fun AnnouncementScreenContent(
     }
 }
 
-@Composable
-fun TopBar(
-    onBackClicked:()->Unit
-){
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 10.dp)
-    ){
-        IconButton(
-            onClick = onBackClicked
-        ) {
-            Icon(
-                imageVector = Icons.Default.ArrowBackIosNew,
-                contentDescription = "Back Arrow",
-                tint= LocalAppColors.current.appTitle,
-                modifier = Modifier.size(25.dp)
-            )
-        }
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.displayMedium.copy(
-                fontFamily = ClashDisplay,
-                color = LocalAppColors.current.appTitle,
-            ),
-            modifier= Modifier.align(Alignment.Center)
-        )
-    }
-}
 
 
 @Preview

--- a/app/src/main/java/com/tpc/nudj/ui/screens/eventRegistration/EventRegistrationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/eventRegistration/EventRegistrationScreen.kt
@@ -39,11 +39,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.tpc.nudj.ui.components.TopBar
 import com.tpc.nudj.ui.screens.eventRegistration.eventRegistrationScreen1.EventRegisterScreen1
 import com.tpc.nudj.ui.screens.eventRegistration.eventRegistrationScreen2.EventRegisterScreen2
 import com.tpc.nudj.ui.screens.eventRegistration.eventRegistrationScreen3.EventRegisterScreen3
 import com.tpc.nudj.ui.screens.eventRegistration.eventRegistrationScreen4.EventRegisterScreen4
-import com.tpc.nudj.ui.screens.myClubs.TopBar
 import com.tpc.nudj.ui.theme.ClashDisplay
 import com.tpc.nudj.ui.theme.LocalAppColors
 import com.tpc.nudj.ui.theme.NudjTheme

--- a/app/src/main/java/com/tpc/nudj/ui/screens/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/homeScreen/HomeScreen.kt
@@ -70,6 +70,7 @@ import com.tpc.nudj.ui.theme.Purple
 import java.text.SimpleDateFormat
 import java.util.*
 import com.tpc.nudj.R
+import com.tpc.nudj.ui.components.TopBar
 import com.tpc.nudj.ui.theme.EditTextBackgroundColorDark
 import com.tpc.nudj.ui.theme.EditTextBackgroundColorLight
 
@@ -383,35 +384,6 @@ fun EventCardMainContent(
     }
 }
 
-@Composable
-fun TopBar(
-    onBackClicked: () -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 10.dp)
-    ) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.displayMedium.copy(
-                fontFamily = ClashDisplay,
-                color = LocalAppColors.current.appTitle
-            ),
-            modifier = Modifier.align(Alignment.Center)
-        )
-        IconButton(
-            onClick = { onBackClicked() }
-        ) {
-            Icon(
-                imageVector = Icons.Default.ArrowBackIosNew,
-                contentDescription = stringResource(R.string.back_navigation),
-                modifier = Modifier.size(25.dp),
-                tint = LocalAppColors.current.appTitle
-            )
-        }
-    }
-}
 
 @Composable
 fun SearchBar(

--- a/app/src/main/java/com/tpc/nudj/ui/screens/myClubs/MyClubsScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/myClubs/MyClubsScreen.kt
@@ -68,6 +68,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.tpc.nudj.model.ClubUser
 import com.tpc.nudj.model.enums.ClubCategory
 import com.tpc.nudj.ui.components.LoadingScreenOverlay
+import com.tpc.nudj.ui.components.TopBar
 import com.tpc.nudj.ui.screens.auth.preHomeScreen.PreHomeScreenLayout
 import com.tpc.nudj.ui.theme.ClashDisplay
 import com.tpc.nudj.ui.theme.EditTextBackgroundColorDark
@@ -420,38 +421,6 @@ fun AllClubsBottomSheetLayout(
         }
     }
 }
-
-@Composable
-fun TopBar(
-    onBackClicked: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-    ) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.displayMedium.copy(
-                fontFamily = ClashDisplay,
-                color = LocalAppColors.current.appTitle
-            ),
-            modifier = Modifier.align(Alignment.Center)
-        )
-        IconButton(
-            onClick = { onBackClicked() }
-        ) {
-            Icon(
-                imageVector = Icons.Default.ArrowBackIosNew,
-                contentDescription = stringResource(R.string.back_navigation),
-                modifier = Modifier.size(25.dp),
-                tint = LocalAppColors.current.appTitle
-            )
-        }
-    }
-}
-
-
 @Preview
 @Composable
 fun ClubCardPreview() {

--- a/app/src/main/java/com/tpc/nudj/ui/screens/rsvp/RSVPConfirmationScreen.kt
+++ b/app/src/main/java/com/tpc/nudj/ui/screens/rsvp/RSVPConfirmationScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tpc.nudj.ui.components.ConfirmationCard
+import com.tpc.nudj.ui.components.TopBar
 import com.tpc.nudj.ui.theme.ClashDisplay
 import com.tpc.nudj.ui.theme.LocalAppColors
 import com.tpc.nudj.ui.theme.NudjTheme
@@ -41,7 +42,9 @@ fun RSVPConfirmationScreen(){
             .background(LocalAppColors.current.landingPageAppTitle)
             .padding(start = 16.dp, end = 16.dp)
     ) {
-        TopBar()
+        TopBar(
+            onBackClicked = {}
+        )
 
         Spacer(modifier = Modifier.height(36.dp))
 
@@ -75,37 +78,6 @@ fun RSVPConfirmationScreen(){
     }
 
 
-}
-
-
-
-@Composable
-fun TopBar(
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 32.dp)
-    ) {
-        Text(
-            text = stringResource(com.tpc.nudj.R.string.app_name),
-            style = MaterialTheme.typography.displayMedium.copy(
-                fontFamily = ClashDisplay,
-                color = LocalAppColors.current.appTitle
-            ),
-            modifier = Modifier.align(Alignment.Center)
-        )
-
-        Icon(
-            imageVector = Icons.Default.ArrowBackIosNew,
-            contentDescription = stringResource(com.tpc.nudj.R.string.back_navigation),
-            modifier = Modifier
-                .size(25.dp)
-                .align(Alignment.CenterStart),
-            tint = LocalAppColors.current.appTitle
-        )
-
-    }
 }
 
 @Preview

--- a/app/src/main/java/com/tpc/nudj/utils/FirestoreUtils.kt
+++ b/app/src/main/java/com/tpc/nudj/utils/FirestoreUtils.kt
@@ -39,7 +39,7 @@ object FirestoreUtils {
             "clubId" to clubUser.clubId,
             "clubName" to clubUser.clubName,
             "description" to clubUser.description,
-            "achievements" to clubUser.achievementsList,
+            "achievementsList" to clubUser.achievementsList,
             "clubEmail" to clubUser.clubEmail,
             "clubLogo" to clubUser.clubLogo,
             "clubCategory" to clubUser.clubCategory.name, // Store enum as string


### PR DESCRIPTION
## 📝Overview
- This PR fixes or fixes part of https://github.com/bsoc-bitbyte/Nudj/issues/66
- This PR does the following: Implements the club profile screen with its (UI + ViewModel) based on the created and verified Figma design , while keeping the colors , theme , fonts and shapes in mind .

## ✅ Checklist
✅ My code follows the project's style and structure
✅ Matches Figma design specifications
✅ Tested locally with no errors

## 📸 Proof that changes are correct
- Added screen recording of the club profile screen layout for any UI changes/feedback.
- Also the previews for the composable functions implemented inside the ClubProfileScreen.kt and EditClubProfileScreen.kt files are made inside the file itself.

https://github.com/user-attachments/assets/11063cf8-acee-45cc-af0c-cee685d2d208

## 🗒️ Additional Notes
- Figma mockup link: [Here](https://www.figma.com/design/Zts7XEdu6oIpMYaTQ8yb7i/Nudj-Contributor-Designs?node-id=0-1&p=f&t=ShPRjnqcaUbiTyXz-0).
- Added reusable TopBar component and replaced existing top bars in all screens.
- Also adjusted some delay values in the ClubDashBoard bottom nav bar for a smoother experience
- Registered the ClubProfileScreen in the ClubDashboard.kt .
- Added the circular progress indicator to ensure a smooth and seamless user experience .
- Used the BaseViewModel and UI states for state management.